### PR TITLE
Add kubectl rollout restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,11 +98,13 @@ dependencies = [
  "memmap2",
  "nu-ansi-term",
  "number_prefix",
+ "openssl",
  "rayon",
  "reqwest",
  "ring",
  "serde",
  "serde_json",
+ "serde_yaml",
  "symbolic-common",
  "symbolic-debuginfo",
  "tame-gcs",
@@ -954,6 +956,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.24.0+1.1.1s"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +973,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -1391,6 +1403,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92b5b431e8907b50339b51223b97d102db8d987ced36f6e4d03621db9316c834"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,6 +1793,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +344,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +367,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -576,16 +616,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.23.2"
+name = "hyper-tls"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "http",
+ "bytes",
  "hyper",
- "rustls",
+ "native-tls",
  "tokio",
- "tokio-rustls",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -621,6 +661,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf64c2edc8226891a71f127587a2861b132d2b942310843814d5001d99a1d307"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -794,6 +843,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +920,51 @@ name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+
+[[package]]
+name = "openssl"
+version = "0.10.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -1087,6 +1199,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,28 +1222,26 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-native-tls",
  "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg",
 ]
 
@@ -1156,27 +1275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
-dependencies = [
- "base64 0.21.0",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1287,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -1218,13 +1325,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "sct"
-version = "0.7.0"
+name = "security-framework"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
- "ring",
- "untrusted",
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1449,6 +1569,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,14 +1683,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.23.4"
+name = "tokio-native-tls"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
- "rustls",
+ "native-tls",
  "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -1658,6 +1791,12 @@ name = "uuid"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1786,25 +1925,6 @@ checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ rayon = "1.5"
 reqwest = { version = "0.11", default-features = false, features = [
   "blocking",
   "json",
-  "rustls-tls",
+  "native-tls",
   "stream",
 ] }
 ring = "0.16"
@@ -49,14 +49,14 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 symbolic-common = { version = "10.0", features = ["serde"] }
 symbolic-debuginfo = { version = "10.0", default-features = false, features = [
-    "breakpad",
-    "dwarf",
-    "elf",
-    "macho",
-    "ms",
-    "ppdb",
-    "sourcebundle",
-    "wasm",
+  "breakpad",
+  "dwarf",
+  "elf",
+  "macho",
+  "ms",
+  "ppdb",
+  "sourcebundle",
+  "wasm",
 ] }
 # GCS requests
 tame-gcs = { version = "0.12", features = ["signing"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ memmap2 = "0.5"
 nu-ansi-term = "0.46"
 # Human friendly byte sizes
 number_prefix = "0.4"
+# Ugh, we _should_ be able to rustls, however...https://github.com/kube-rs/kube/issues/153
+openssl = { version = "0.10", features = ["vendored"] }
 rayon = "1.5"
 # For HTTP requests
 reqwest = { version = "0.11", default-features = false, features = [
@@ -47,6 +49,7 @@ ring = "0.16"
 serde = { version = "1.0", features = ["derive"] }
 # JSON serialization
 serde_json = "1.0"
+serde_yaml = "0.9"
 symbolic-common = { version = "10.0", features = ["serde"] }
 symbolic-debuginfo = { version = "10.0", default-features = false, features = [
   "breakpad",

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -273,7 +273,9 @@ struct Item {
     targets: Vec<TaggedImage>,
 }
 
-pub async fn run(args: Args, client: reqwest::Client) -> anyhow::Result<()> {
+pub async fn run(args: Args, client: reqwest::ClientBuilder) -> anyhow::Result<()> {
+    let client = client.build()?;
+
     let mc = {
         use std::io::Read;
         let mut mc = String::new();

--- a/src/gcs.rs
+++ b/src/gcs.rs
@@ -13,9 +13,9 @@ impl crate::Scopes for Args {
     }
 }
 
-pub async fn run(args: Args, client: reqwest::Client) -> anyhow::Result<()> {
+pub async fn run(args: Args, client: reqwest::ClientBuilder) -> anyhow::Result<()> {
     let rctx = util::RequestContext {
-        client,
+        client: client.build()?,
         obj: tame_gcs::objects::Object::default(),
     };
 

--- a/src/kms.rs
+++ b/src/kms.rs
@@ -94,7 +94,7 @@ struct Ciphertext {
 }
 
 /// <https://cloud.google.com/kms/docs/encrypt-decrypt#encrypt>
-async fn encrypt(args: Encrypt, client: reqwest::Client) -> anyhow::Result<()> {
+async fn encrypt(args: Encrypt, client: Client) -> anyhow::Result<()> {
     let url = format!("https://cloudkms.googleapis.com/v1/projects/{project}/locations/{location}/keyRings/{keyring}/cryptoKeys/{key}:encrypt",
         project = args.key_info.project,
         location = args.key_info.location,
@@ -130,7 +130,7 @@ async fn encrypt(args: Encrypt, client: reqwest::Client) -> anyhow::Result<()> {
 }
 
 /// <https://cloud.google.com/kms/docs/encrypt-decrypt#decrypt>
-async fn decrypt(args: Decrypt, client: reqwest::Client) -> anyhow::Result<()> {
+async fn decrypt(args: Decrypt, client: Client) -> anyhow::Result<()> {
     let url = format!("https://cloudkms.googleapis.com/v1/projects/{project}/locations/{location}/keyRings/{keyring}/cryptoKeys/{key}:decrypt",
         project = args.key_info.project,
         location = args.key_info.location,
@@ -170,7 +170,9 @@ async fn decrypt(args: Decrypt, client: reqwest::Client) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn run(args: Args, client: Client) -> anyhow::Result<()> {
+pub async fn run(args: Args, client: reqwest::ClientBuilder) -> anyhow::Result<()> {
+    let client = client.build()?;
+
     match args {
         Args::Encrypt(args) => encrypt(args, client).await?,
         Args::Decrypt(args) => decrypt(args, client).await?,

--- a/src/kubectl.rs
+++ b/src/kubectl.rs
@@ -1,14 +1,24 @@
+use anyhow::Context as _;
 pub mod rollout;
 
 #[derive(clap::Subcommand)]
 pub enum Subcommand {
+    /// Manage the rollout of a resource
     Rollout(rollout::Args),
 }
 
+/// A small kubectl replacement. Note that this does not currently support
+/// incluster configuration as it assumes it is being run somewhere other than
+/// the target cluster
 #[derive(clap::Parser)]
 pub struct Args {
+    /// Path to a kubeconfig file to load the cluster host and cert information from
     #[clap(long)]
-    cluster: String,
+    kubeconfig: camino::Utf8PathBuf,
+    /// The name of the context, must be specified if there is more than one in the config
+    #[clap(long)]
+    cluster: Option<String>,
+    /// The namespace in the cluster to operate on
     #[clap(short, long)]
     namespace: String,
     #[clap(subcommand)]
@@ -22,7 +32,7 @@ impl crate::Scopes for Args {
 }
 
 pub struct K8sClient {
-    cluster: String,
+    server: String,
     namespace: String,
     client: reqwest::Client,
 }
@@ -33,18 +43,98 @@ impl K8sClient {
         // URL encoded, however if we ever have namespaces/names
         // that _need_ to be URL encoded, we deserve what we get
         format!(
-            "https://{}/apis/apps/v1/namespaces/{}/{kind}/{name}?",
-            self.cluster, self.namespace,
+            "{}/apis/apps/v1/namespaces/{}/{kind}/{name}?",
+            self.server, self.namespace,
         )
     }
 }
 
-pub async fn run(args: Args, client: reqwest::Client) -> anyhow::Result<()> {
-    let client = K8sClient {
-        cluster: args.cluster,
-        namespace: args.namespace,
-        client,
+fn load_config(
+    config_path: camino::Utf8PathBuf,
+    namespace: String,
+    cluster: Option<String>,
+    builder: reqwest::ClientBuilder,
+) -> anyhow::Result<K8sClient> {
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    struct ClusterDetails {
+        server: String,
+        #[serde(rename = "certificate-authority-data")]
+        cert_data: String,
+    }
+
+    #[derive(Deserialize)]
+    struct ClusterConfig {
+        name: String,
+        cluster: ClusterDetails,
+    }
+
+    #[derive(Deserialize)]
+    struct KubeConfig {
+        clusters: Vec<ClusterConfig>,
+    }
+
+    let config_data = std::fs::read_to_string(&config_path)
+        .with_context(|| format!("failed to read kubeconfig '{config_path}'"))?;
+    let config: KubeConfig = serde_yaml::from_str(&config_data)
+        .with_context(|| format!("failed to deserialize kubeconfig '{config_path}'"))?;
+
+    let mut clusters = config.clusters;
+
+    anyhow::ensure!(
+        !clusters.is_empty(),
+        "no clusters were defined in '{config_path}'"
+    );
+
+    let details = if let Some(cluster_name) = cluster {
+        clusters
+            .into_iter()
+            .find_map(|cc| {
+                if cc.name == cluster_name {
+                    Some(cc.cluster)
+                } else {
+                    None
+                }
+            })
+            .with_context(|| {
+                format!("failed to find cluster '{cluster_name}' in '{config_path}'")
+            })?
+    } else if clusters.len() > 1 {
+        let mut names = String::new();
+
+        for cluster in clusters.into_iter().map(|cc| cc.name) {
+            use std::fmt::Write;
+            write!(&mut names, "{cluster}, ").unwrap();
+        }
+
+        names.pop();
+        names.pop();
+
+        anyhow::bail!("there were multiple clusters to choose from [{names}], you must specify which one to use via --cluster");
+    } else {
+        clusters.pop().context("unreachable")?.cluster
     };
+
+    use base64::Engine;
+
+    let cert = base64::engine::general_purpose::STANDARD
+        .decode(details.cert_data)
+        .context("failed to decode cert")?;
+
+    let cert = openssl::x509::X509::from_pem(&cert).context("failed to load cert")?;
+
+    let client_b = builder.add_root_certificate(reqwest::Certificate::from_der(&cert.to_der()?)?);
+
+    Ok(K8sClient {
+        server: details.server,
+        namespace,
+        client: client_b.build()?,
+    })
+}
+
+pub async fn run(args: Args, builder: reqwest::ClientBuilder) -> anyhow::Result<()> {
+    let client = load_config(args.kubeconfig, args.namespace, args.cluster, builder)?;
 
     match args.cmd {
         Subcommand::Rollout(args) => rollout::run(client, args).await,

--- a/src/kubectl.rs
+++ b/src/kubectl.rs
@@ -1,0 +1,52 @@
+pub mod rollout;
+
+#[derive(clap::Subcommand)]
+pub enum Subcommand {
+    Rollout(rollout::Args),
+}
+
+#[derive(clap::Parser)]
+pub struct Args {
+    #[clap(long)]
+    cluster: String,
+    #[clap(short, long)]
+    namespace: String,
+    #[clap(subcommand)]
+    cmd: Subcommand,
+}
+
+impl crate::Scopes for Args {
+    fn scopes(&self) -> &'static [&'static str] {
+        &["https://www.googleapis.com/auth/cloud-platform"]
+    }
+}
+
+pub struct K8sClient {
+    cluster: String,
+    namespace: String,
+    client: reqwest::Client,
+}
+
+impl K8sClient {
+    fn make_url(&self, kind: &str, name: &str) -> String {
+        // Note that the namespace and resource name should be
+        // URL encoded, however if we ever have namespaces/names
+        // that _need_ to be URL encoded, we deserve what we get
+        format!(
+            "https://{}/apis/apps/v1/namespaces/{}/{kind}/{name}?",
+            self.cluster, self.namespace,
+        )
+    }
+}
+
+pub async fn run(args: Args, client: reqwest::Client) -> anyhow::Result<()> {
+    let client = K8sClient {
+        cluster: args.cluster,
+        namespace: args.namespace,
+        client,
+    };
+
+    match args.cmd {
+        Subcommand::Rollout(args) => rollout::run(client, args).await,
+    }
+}

--- a/src/kubectl/rollout.rs
+++ b/src/kubectl/rollout.rs
@@ -1,0 +1,64 @@
+use anyhow::Context as _;
+
+#[derive(clap::Subcommand)]
+pub enum Subcommand {
+    Restart { resource: String },
+}
+
+#[derive(clap::Parser)]
+pub struct Args {
+    #[clap(subcommand)]
+    cmd: Subcommand,
+}
+
+fn parse_resource(resource: &str) -> anyhow::Result<(&str, &str)> {
+    let ind = resource
+        .find('/')
+        .context("resource must be specified as <kind>/<name>")?;
+
+    let kind = match &resource[..ind] {
+        "deployment" => "deployments",
+        other => anyhow::bail!("unknown resource kind '{other}'"),
+    };
+
+    anyhow::ensure!(
+        ind + 1 < resource.len(),
+        "the resource name was not provided"
+    );
+
+    Ok((kind, &resource[ind + 1..]))
+}
+
+pub(super) async fn run(client: super::K8sClient, args: Args) -> anyhow::Result<()> {
+    match args.cmd {
+        Subcommand::Restart { resource } => {
+            let patch = serde_json::json!({
+              "spec": {
+                "template": {
+                  "metadata": {
+                    "annotations": {
+                      "boh.kubernetes.io/restartedAt": time::OffsetDateTime::now_utc().format(&time::format_description::well_known::Rfc3339).context("failed to format timestamp")?,
+                    }
+                  }
+                }
+              }
+            });
+
+            let (kind, name) = parse_resource(&resource)?;
+
+            let url = client.make_url(kind, name);
+
+            client
+                .client
+                .patch(url)
+                .header(http::header::ACCEPT, "application/json")
+                .header(http::header::CONTENT_TYPE, "application/merge-patch+json")
+                .body(serde_json::to_vec(&patch).context("failed to write serialize json patch")?)
+                .send()
+                .await?
+                .error_for_status()?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod artifact;
 pub mod gcs;
 pub mod kms;
+pub mod kubectl;
 pub mod syms;
 
 pub trait Scopes {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,16 +35,13 @@ async fn main() -> anyhow::Result<()> {
         hm
     };
 
-    let client = reqwest::Client::builder()
-        .default_headers(hm)
-        .build()
-        .context("failed to build client")?;
+    let client_builder = reqwest::Client::builder().default_headers(hm);
 
     match args {
-        Args::Artifact(gcs) => boh::artifact::run(gcs, client).await?,
-        Args::Gcs(gcs) => boh::gcs::run(gcs, client).await?,
-        Args::Kms(kms) => boh::kms::run(kms, client).await?,
-        Args::Kubectl(kube) => boh::kubectl::run(kube, client).await?,
+        Args::Artifact(gcs) => boh::artifact::run(gcs, client_builder).await?,
+        Args::Gcs(gcs) => boh::gcs::run(gcs, client_builder).await?,
+        Args::Kms(kms) => boh::kms::run(kms, client_builder).await?,
+        Args::Kubectl(kube) => boh::kubectl::run(kube, client_builder).await?,
         Args::Syms(syms) => {
             let hm = {
                 let mut hm = reqwest::header::HeaderMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,12 @@ use clap::Parser;
 #[derive(Parser)]
 #[clap(author, version, about)]
 enum Args {
-    #[clap(subcommand)]
-    Kms(boh::kms::Args),
+    Artifact(boh::artifact::Args),
     #[clap(subcommand)]
     Gcs(boh::gcs::Args),
-    Artifact(boh::artifact::Args),
+    #[clap(subcommand)]
+    Kms(boh::kms::Args),
+    Kubectl(boh::kubectl::Args),
     Syms(boh::syms::Args),
 }
 
@@ -18,9 +19,10 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     let scopes = match &args {
-        Args::Kms(a) => a.scopes(),
-        Args::Gcs(a) => a.scopes(),
         Args::Artifact(a) => a.scopes(),
+        Args::Gcs(a) => a.scopes(),
+        Args::Kms(a) => a.scopes(),
+        Args::Kubectl(a) => a.scopes(),
         Args::Syms(a) => a.scopes(),
     };
 
@@ -39,9 +41,10 @@ async fn main() -> anyhow::Result<()> {
         .context("failed to build client")?;
 
     match args {
-        Args::Kms(kms) => boh::kms::run(kms, client).await?,
-        Args::Gcs(gcs) => boh::gcs::run(gcs, client).await?,
         Args::Artifact(gcs) => boh::artifact::run(gcs, client).await?,
+        Args::Gcs(gcs) => boh::gcs::run(gcs, client).await?,
+        Args::Kms(kms) => boh::kms::run(kms, client).await?,
+        Args::Kubectl(kube) => boh::kubectl::run(kube, client).await?,
         Args::Syms(syms) => {
             let hm = {
                 let mut hm = reqwest::header::HeaderMap::new();


### PR DESCRIPTION
This adds a `boh kubectl rollout restart deployment/<blah>` command as it is literally the only thing we used kubectl for, and because of the incredibly lame dependency of the GKE auth plugin on gcloud (fucking ridiculous 600+MiB install size) as well as removing the need to have python!?!?!?! Beyond pissed at this garbage fire.

Unfortunately, this means using openssl instead of rustls, due to...[reasons](https://github.com/kube-rs/kube/issues?q=is%3Aopen+is%3Aissue+label%3Arustls).